### PR TITLE
LocalStorageに保存されたデータのエクスポート/インポート機能の追加

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -461,6 +461,7 @@ var Sys = React.createClass({
             dataName: '',
             selectedData: '',
             uploadedData: '',
+            rawData: '',
         };
     },
     componentDidMount: function(){
@@ -559,6 +560,15 @@ var Sys = React.createClass({
     onSubmitUpload: function(e){
         console.log("データアップロードテスト")
     },
+    onSubmitSaveRawData: function(e){
+        var rawData = JSON.stringify(this.state.storedData);
+        this.setState({rawData: rawData});
+    },
+    onSubmitLoadRawData: function(e){
+        var storedData = JSON.parse(this.state.rawData);
+        this.setState({storedData: storedData});
+        this.setState({selectedData: Object.keys(storedData)[0]});
+    },
     render: function() {
         var locale = this.props.locale;
         var datalist = []
@@ -588,6 +598,14 @@ var Sys = React.createClass({
                 </FormGroup>
                 */}
                 <TwitterShareButton data={this.props.data} dataName={this.state.dataName} locale={locale} />
+                <FormGroup>
+                    {intl.translate("データ移行", locale)}
+                    <FormControl componentClass="textarea" value={this.state.rawData} onChange={this.handleEvent.bind(this, "rawData")} />
+                    <ButtonGroup>
+                    <Button tye="submit" bsStyle="primary" onClick={this.onSubmitSaveRawData}>{intl.translate("移行データ出力", locale)}</Button>
+                    <Button tye="submit" bsStyle="primary" onClick={this.onSubmitLoadRawData}>{intl.translate("移行データ入力", locale)}</Button>
+                    </ButtonGroup>
+                </FormGroup>
             </div>
         );
     }

--- a/src/translate.js
+++ b/src/translate.js
@@ -61,6 +61,18 @@ var multiLangData = {
         "en": "Save to Browser",
         "ja": "保存",
     },
+    "データ移行": {
+        "en": "Export/Import",
+        "ja": "データ移行",
+    },
+    "移行データ出力": {
+        "en": "Export",
+        "ja": "データ出力",
+    },
+    "移行データ入力": {
+        "en": "Import",
+        "ja": "データ入力",
+    },
     "ダウンロード": {
         "en": "Download",
         "ja": "ダウンロード",


### PR DESCRIPTION
# 概要
LocalStorageに保存されたデータのエクスポート/インポートを行う機能です。

# 目的と用途
[ブラウザに保存]機能を使ってLocalStorageに保存したデータのバックアップとリストア、あるいは異なる端末の同データの端末間同期を行うためです。

現状のmotocalには[サーバに保存]機能やIssue #28 のJSONダウンロード/アップロード機能(仕掛かり中)がありますが、いずれも対象が編成単位であり、前述の目的には少々不便です。別のツールですが、[グラブル装備シミュレータ](http://gbf.xzz.jp/)にあるデータ移行機能が便利でしたので、それに似せて作りました。

※プロジェクトの移管がらみで新たにgithubプロジェクトを立て直すなど計画されている場合は、新しい方に投げ直すのでその旨ご連絡頂ければと思います。
